### PR TITLE
fixed the problem of when selecting part of the sites.

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -42,8 +42,10 @@
             initialized: false,
         };
 
-        var $globals = $.extend(true, $defaults, $options);
-
+        var $globals = $defaults;
+        for(attr in $options){
+            $globals[attr] = $options[attr];
+        }
         var $templates = {
             qzone       : 'http://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url={{URL}}&title={{TITLE}}&desc={{DESCRIPTION}}&summary={{SUMMARY}}&site={{SOURCE}}',
             qq          : 'http://connect.qq.com/widget/shareqq/index.html?url={{URL}}&title={{TITLE}}&source={{SOURCE}}&desc={{DESCRIPTION}}',


### PR DESCRIPTION
the problem can be described as :

the default
` ['weibo','qq','wechat','tencent','douban','qzone','linkedin','diandian','facebook','twitter','google'],`
the config 
` ['facebook','wechat']`

then global.sites will be
`['facebook','wechat','wechat','tencent','douban','qzone','linkedin','diandian','facebook','twitter','google'],
`
because $.extend will only replace the part in config and longer part will be kept in the array.

Maybe some more efficient way can be done than my naive solution.