### PR TITLE
check disabled items exits in sites before using Array.splice to remove

### DIFF
--- a/src/js/jquery.share.js
+++ b/src/js/jquery.share.js
@@ -138,7 +138,10 @@
 
             // Remove elements
             $disabled.length && $.each($disabled, function (i, el) {
-                $sites.splice($.inArray(el, $sites), 1);
+                var removeItemIndex = $.inArray(el, $sites);
+                if (removeItemIndex !== -1) {
+                    $sites.splice(removeItemIndex, 1);
+                }                
             });
             
             return $sites;


### PR DESCRIPTION
如果同时声明了`$sites` 和 `$disabled`时，显示的图标会少`$disabled.length`个，原因是在`Array.splice`前没有检查数组中是否存在对象。